### PR TITLE
add fastrtps config file

### DIFF
--- a/fastrtps.meta
+++ b/fastrtps.meta
@@ -1,7 +1,7 @@
 {
     "names": {
         "fastrtps": {
-            "cmake-args": ["-DSECURITY=ON"],
+            "cmake-args": ["-DSECURITY=ON"]
         }
     }
 }

--- a/fastrtps.meta
+++ b/fastrtps.meta
@@ -1,0 +1,8 @@
+{
+    "names": {
+        "fastrtps": {
+            "cmake-args": ["-DSECURITY=ON"],
+            "dependencies": ["fastcdr"],
+        }
+    }
+}

--- a/fastrtps.meta
+++ b/fastrtps.meta
@@ -2,7 +2,6 @@
     "names": {
         "fastrtps": {
             "cmake-args": ["-DSECURITY=ON"],
-            "dependencies": ["fastcdr"],
         }
     }
 }

--- a/index.yaml
+++ b/index.yaml
@@ -1,2 +1,3 @@
 metadata:
+  - fastrtps.meta
   - Gazebo.meta


### PR DESCRIPTION
This allows to work around the explicit presence of `find_package(fastcdr)` in the CMakeLists.txt (https://github.com/eProsima/Fast-RTPS/pull/207/files)

ROS 2 developpers can use this locally and it should allow them to get rid of the CMake Warnings on all packages due to the fact that we pass SECURITY globally right now