### PR TITLE
add default Ignition workspace configuration

### DIFF
--- a/ignition-default.meta
+++ b/ignition-default.meta
@@ -1,0 +1,7 @@
+{
+    "paths": {
+        "src/ign-rendering": {
+            "cmake-args": ["-DSKIP_optix=true"]
+        }
+    }
+}

--- a/index.yaml
+++ b/index.yaml
@@ -1,3 +1,4 @@
 metadata:
   - fastrtps.meta
   - Gazebo.meta
+  - ignition-default.meta


### PR DESCRIPTION
Since Ignition packages have many optional components, it would be nice to provide users with a "default" configuration that specifies which optional components should be used. This is especially useful for users who are new to Ignition and simply want to "try out" a source build. Providing this "default" configuration also removes build warnings related to optional components that aren't intended to be used (see https://github.com/ignitionrobotics/ign-cmake/pull/165), which prevents newer users from being confused about the severity of warnings they'd see otherwise if building Ignition packages from source without this "default" configuration.

`paths` are used to define Ignition packages instead of `names` since this default configuration is designed to work for any of the Ignition versions that are currently supported. If `names` were to be used, separate meta files would be needed for each Ignition version - for example, one file might have `ign-rendering4`, while another would have `ign-rendering5` - but since the default configuration for each Ignition version is the same at the time of this writing, using `names` would mean duplicate/repetitive meta files, which is not ideal for maintenance. The paths being used here assume that the source installation instructions from https://ignitionrobotics.org/docs are being followed (using `vcs` to clone all of the repositories directly inside of the `src` directory, and calling `colcon build` from the root of the workspace).

It's likely that this file will be iterated on in the future as new components are added to Ignition packages (for example, when bullet physics engine is added to `ign-physics`: https://github.com/ignitionrobotics/ign-physics/pull/208), and also if any more related features are added to `ign-cmake` (we are considering adding a `REQUIRE` variable to complement the `SKIP` variable that was introduced in the `ign-cmake` PR I linked to above).