### PR TITLE
add note about installing yamllint to run lint.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,5 +32,5 @@ For each contribution perform the following steps:
 * Create or modify one or multiple files ending with `.meta`.
 * Add any new files in alphabetical order to the `index.yaml` file.
 * Run the `lint.py` script to ensure that the changes follow the recommended
-  yaml style.
+  yaml style (you'll need to install [yamllint](https://yamllint.readthedocs.io/en/stable/index.html) in order to run `lint.py`)
 * Create a pull request with the changes.

--- a/README.md
+++ b/README.md
@@ -32,5 +32,8 @@ For each contribution perform the following steps:
 * Create or modify one or multiple files ending with `.meta`.
 * Add any new files in alphabetical order to the `index.yaml` file.
 * Run the `lint.py` script to ensure that the changes follow the recommended
-  yaml style (you'll need to install [yamllint](https://yamllint.readthedocs.io/en/stable/index.html) in order to run `lint.py`)
+  yaml style.
+  
+  * The script requires [yamllint](https://yamllint.readthedocs.io/en/stable/index.html) to be installed.
+
 * Create a pull request with the changes.


### PR DESCRIPTION
I didn't have `yamllint` installed when trying to run `lint.py`, so I thought that adding a note/link to this package in the `README` instructions may help other users who need to install it as well.