### PR TITLE
Add fastdds config file

### DIFF
--- a/fastdds.meta
+++ b/fastdds.meta
@@ -1,0 +1,7 @@
+{
+    "names": {
+        "fastdds": {
+            "cmake-args": ["-DSECURITY=ON"]
+        }
+    }
+}

--- a/index.yaml
+++ b/index.yaml
@@ -1,3 +1,4 @@
 metadata:
+  - fastdds.meta
   - fastrtps.meta
   - Gazebo.meta


### PR DESCRIPTION
Duplicate the configuration from fastrtps.meta into fastdds.meta, so the same build configuration is used independently of the package name.