### PR TITLE
Add `fastdds` package to `fastrtps.meta`

### DIFF
--- a/fastrtps.meta
+++ b/fastrtps.meta
@@ -3,5 +3,8 @@
         "fastrtps": {
             "cmake-args": ["-DSECURITY=ON"]
         }
+        "fastdds": {
+            "cmake-args": ["-DSECURITY=ON"]
+        }
     }
 }


### PR DESCRIPTION
Make users depending on this metadata repository use the same configuration when building `fastrtps` and `fastdds` packages